### PR TITLE
feat: allow for flex direction customization

### DIFF
--- a/src/PressbooksMultiselect.js
+++ b/src/PressbooksMultiselect.js
@@ -18,8 +18,7 @@ export class PressbooksMultiselect extends LitElement {
 
       .selected-options {
         display: flex;
-        flex-wrap: wrap;
-        flex-direction: var(--pb-selected-options-flex-direction, row);
+        flex-flow: var(--pb-selected-options-flex-direction, row) wrap;
         gap: 0.5rem;
         list-style-type: none;
         max-width: var(--pb-selected-options-max-width, 100%);

--- a/src/PressbooksMultiselect.js
+++ b/src/PressbooksMultiselect.js
@@ -19,6 +19,7 @@ export class PressbooksMultiselect extends LitElement {
       .selected-options {
         display: flex;
         flex-wrap: wrap;
+        flex-direction: var(--pb-selected-options-flex-direction, row);
         gap: 0.5rem;
         list-style-type: none;
         max-width: var(--pb-selected-options-max-width, 100%);


### PR DESCRIPTION
I'm using the component in the new Multi Institution plugin that we're building and there's a need to display the selected options vertically (one item per line). Would you be willing to accept this PR allowing for flex direction customization?

I wanted to avoid doing hacky things to handle that on our side.