### PR TITLE
fix: after slot hint

### DIFF
--- a/demo/index.html
+++ b/demo/index.html
@@ -32,7 +32,7 @@
   <main id="main">
     <pressbooks-multiselect>
       <label for="dwarves">Dwarves</label>
-        <p id="dwarves-hint">Type to choose some dwarves.</p>
+        <p id="dwarves-hint" slot="after">Type to choose some dwarves.</p>
         <select
           id="dwarves"
           name="dwarves[]"

--- a/src/PressbooksMultiselect.js
+++ b/src/PressbooksMultiselect.js
@@ -320,12 +320,31 @@ export class PressbooksMultiselect extends LitElement {
   }
 
   get _hint() {
-    const slot = this.shadowRoot.querySelector('slot');
+    const defaultSlot = this.shadowRoot.querySelector('slot:not([name])');
+    const afterSlot = this.shadowRoot.querySelector('slot[name="after"]');
+
     if (this._select.getAttribute('aria-describedby')) {
       const hintId = this._select.getAttribute('aria-describedby');
-      return slot
-        .assignedElements()
-        .filter(node => node.matches(`#${hintId}`))[0];
+
+      // Check in default slot
+      const defaultElements = defaultSlot.assignedElements();
+      const hintInDefault = defaultElements.filter(node =>
+        node.matches(`#${hintId}`),
+      )[0];
+      if (hintInDefault) {
+        return hintInDefault;
+      }
+
+      // Check in after slot
+      if (afterSlot) {
+        const afterElements = afterSlot.assignedElements();
+        const hintInAfter = afterElements.filter(node =>
+          node.matches(`#${hintId}`),
+        )[0];
+        if (hintInAfter) {
+          return hintInAfter;
+        }
+      }
     }
 
     return false;


### PR DESCRIPTION
This pull request updates the `PressbooksMultiselect` component to support a new `slot="after"` for hints, improving flexibility in how hints are displayed. The changes include updates to the HTML structure and the `_hint` getter method to accommodate this new slot.

### Enhancements to hint slot functionality:

* [`demo/index.html`](diffhunk://#diff-b18ccd15ec95e2a9c4fead5bca9085042af688361a24d3463c27138e3c797a5bL35-R35): Updated the `dwarves-hint` paragraph to use the new `slot="after"` attribute, allowing it to be displayed in the "after" slot.
* [`src/PressbooksMultiselect.js`](diffhunk://#diff-b8d19440a2206d955cd9d13f8a8c5c68f5f3ec4d06e88860b64d265a2f1f9a93L323-R347): Modified the `_hint` getter to check both the default slot and the new "after" slot for the hint element, ensuring compatibility with the updated slot structure.